### PR TITLE
Use process.env for PORT

### DIFF
--- a/src/tasks/app.js
+++ b/src/tasks/app.js
@@ -7,10 +7,13 @@ const appJs = (db) => {
   return `import express from 'express';
         import bodyParser from 'body-parser';
         import cors from 'cors';
+        import dotenv from 'dotenv';
         import routes from './routes';
         ${setUpRequired}
         
-        const port = 8000;
+        dotenv.config();
+        
+        const port = process.env.PORT || 8000;
         const app = express();
         
         app.use(bodyParser.json());


### PR DESCRIPTION
Had trouble starting the app that is created but this change should work to fix #107.

Here is the error I am met with when running `npm run start` inside the created directory:
```> example@1.0.0 start /Users/AWS11/Documents/nodejs-api-cli/example
> babel-node src/index.js

/Users/****/Documents/nodejs-api-cli/example/node_modules/@babel/core/lib/parser/index.js:95
    throw err;
    ^

SyntaxError: /Users/****/Documents/nodejs-api-cli/example/src/controllers/user.js: Can not use keyword 'await' outside an async function (30:4)

  28 | }
  29 | export const signupUserController = (req, res) => {
> 30 |     await query(createUserQuery, async (err, result) => {
     |     ^
  31 |         if (err) {
  32 |             return responseHandler(res, err, 500);
  33 |         }
    at Parser._raise (/Users/****/Documents/nodejs-api-cli/example/node_modules/@babel/parser/src/parser/error.js:60:45)
    at Parser.raiseWithData (/Users/****/Documents/nodejs-api-cli/example/node_modules/@babel/parser/src/parser/error.js:55:17)
    at Parser.raise (/Users/****/Documents/nodejs-api-cli/example/node_modules/@babel/parser/src/parser/error.js:39:17)
    at Parser.checkReservedWord (/Users/****/Documents/nodejs-api-cli/example/node_modules/@babel/parser/src/parser/expression.js:2415:14)
    at Parser.parseIdentifierName (/Users/****/Documents/nodejs-api-cli/example/node_modules/@babel/parser/src/parser/expression.js:2362:12)
    at Parser.parseIdentifier (/Users/****/Documents/nodejs-api-cli/example/node_modules/@babel/parser/src/parser/expression.js:2320:23)
    at Parser.parseExprAtom (/Users/****/Documents/nodejs-api-cli/example/node_modules/@babel/parser/src/parser/expression.js:997:25)
    at Parser.parseExprSubscripts (/Users/****/Documents/nodejs-api-cli/example/node_modules/@babel/parser/src/parser/expression.js:563:23)
    at Parser.parseUpdate (/Users/****/Documents/nodejs-api-cli/example/node_modules/@babel/parser/src/parser/expression.js:543:21)
    at Parser.parseMaybeUnary (/Users/****/Documents/nodejs-api-cli/example/node_modules/@babel/parser/src/parser/expression.js:527:17) {
  loc: Position { line: 30, column: 4 },
  pos: 850,
  code: 'BABEL_PARSE_ERROR'
}```